### PR TITLE
fixed some eslint warning errors

### DIFF
--- a/client/src/pages/Contact.js
+++ b/client/src/pages/Contact.js
@@ -21,7 +21,6 @@ function Contact() {
     if (errorMessage) {
       return;
     }
-    console.log(formState);
 
     const { data } = await sendContactEmail({ variables: formState });
     setResponse(data.sendContactEmail);

--- a/client/src/utils/GlobalState.js
+++ b/client/src/utils/GlobalState.js
@@ -10,8 +10,7 @@ const StoreProvider = ({ ...props }) => {
     categories: [],
     currentCategory: '',
   });
-  // use this to confirm it works!
-  console.log(state);
+
   return <Provider value={[state, dispatch]} {...props} />;
 };
 

--- a/client/src/utils/helpers.js
+++ b/client/src/utils/helpers.js
@@ -30,12 +30,12 @@ export function idbPromise(storeName, method, object) {
     };
 
     // handle any errors with connecting
-    request.onerror = function () {
+    request.onerror = () => {
       console.log('There was an error');
     };
 
     // on database open success
-    request.onsuccess = function () {
+    request.onsuccess = () => {
       // save a reference of the database to the `db` variable
       db = request.result;
       // open a transaction do whatever we pass into `storeName` (must match one of the object store names)
@@ -44,7 +44,7 @@ export function idbPromise(storeName, method, object) {
       store = tx.objectStore(storeName);
 
       // if there's any errors, let us know
-      db.onerror = function (e) {
+      db.onerror = (e) => {
         console.log('error', e);
       };
 
@@ -55,7 +55,7 @@ export function idbPromise(storeName, method, object) {
           break;
         case 'get': {
           const all = store.getAll();
-          all.onsuccess = function () {
+          all.onsuccess = () => {
             resolve(all.result);
           };
           break;
@@ -69,7 +69,7 @@ export function idbPromise(storeName, method, object) {
       }
 
       // when the transaction is complete, close the connection
-      tx.oncomplete = function () {
+      tx.oncomplete = () => {
         db.close();
       };
     };

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -103,7 +103,6 @@ const resolvers = {
       return { token, user };
     },
     addOrder: async (parent, { items }, context) => {
-      console.log(context);
       if (context.user) {
         const order = new Order({ items });
 


### PR DESCRIPTION
There were several warning errors from eslint. I fixed most of them. The remaining ones are either console logs that should stay (write warning messages or explain errors) or a couple of others with renaming functions, but all are fine to leave since they are warnings. The remaining errors shop up in the browser console and in the terminal, but can be ignored.